### PR TITLE
Add remove method to title and text

### DIFF
--- a/assets/scripts/contents/ui.js
+++ b/assets/scripts/contents/ui.js
@@ -81,6 +81,8 @@ const onSavePost = function (id, title, date, text, type) {
     type: newType
   }
 }
+  title.remove()
+  text.remove()
   api.updateContent(data, id)
     .then(updatePostSuccess)
     .catch(updatePostFailure)
@@ -140,6 +142,8 @@ const onSavePage = function (id, title, date, text, type) {
     type: newType
   }
 }
+  title.remove()
+  text.remove()
   api.updateContent(data, id)
     .then(updatePageSuccess)
     .catch(updatePageFailure)


### PR DESCRIPTION
In the 'savePost' and 'savePage' method I added the remove method to
both so that the items will be quickly removed but then reappear
quickly due to the getContents api. It happens so quickly that it's not
noticeable. I did this because it wasn't editing in real time
consistently and found that this method works every time.