### PR TITLE
Fixed .html bug

### DIFF
--- a/assets/scripts/contents/ui.js
+++ b/assets/scripts/contents/ui.js
@@ -68,10 +68,10 @@ const onEditPost = function (event) {
 }
 
 const onSavePost = function (id, title, date, text, type) {
-  const newTitle = $(title).html()
-  const newText = $(text).html()
-  const newDate = $(date).html().trim()
-  const newType = $(type).html()
+  const newTitle = $(title).text()
+  const newText = $(text).text()
+  const newDate = $(date).text().trim()
+  const newType = $(type).text()
   const data =
 {
   content: {
@@ -126,10 +126,10 @@ const onEditPage = function (event) {
 }
 
 const onSavePage = function (id, title, date, text, type) {
-  const newTitle = $(title).html()
-  const newText = $(text).html()
-  const newDate = $(date).html().trim()
-  const newType = $(type).html()
+  const newTitle = $(title).text()
+  const newText = $(text).text()
+  const newDate = $(date).text().trim()
+  const newType = $(type).text()
   const data =
 {
   content: {
@@ -167,7 +167,6 @@ const getPagesFailure = function () {
 }
 
 const updatePostSuccess = function () {
-  console.log('YEAH BUDDY')
   $('#message').text('Post updated')
   api.getContent()
     .then(getPostsSuccess)


### PR DESCRIPTION
For Edit Content (Page & Post): When the data object was prepared to be
sent to the api, .html was used to reconfigure the data. This created a
bug where entering &, <, or > would make visible the meta charset value.
This was fixed by changing .html to .text

Ripley solo