### PR TITLE
Visitor Search Fields set to Username

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
         <div id="blogcontent">
           <div class="Blogs">
             <form class="get-blogs">
-                <input type="text" name="email" placeholder="Enter Email Address">
+                <input type="text" name="email" placeholder="Enter Username">
                 <input type="submit" name="get blogs" value="Get Blog" class="btn btn-primary">
             </form>
           </div>
@@ -171,7 +171,7 @@
       <div id="pagecontent">
         <div class="pages">
           <form class="get-page-list">
-              <input type="text" name="email" placeholder="Enter Email Address">
+              <input type="text" name="email" placeholder="Enter Username">
               <input type="submit" name="get-page-list" value="Get Page List" class="btn btn-primary">
           </form>
           <select class="hidden" name="selectPage" id="selectPage"></select>


### PR DESCRIPTION
Removed "email address" from both visitor content search fields and then
replaced it with "username" to reflect language on the rest of the site

Ripley solo